### PR TITLE
Add initial RpgRooms solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# projetorpg teste
+# RpgRooms
+
+Projeto de exemplo de salas para campanhas de RPG usando Blazor, EF Core e SignalR.
+
+## Execução
+
+1. Restaure os pacotes:
+   ```bash
+   dotnet restore
+   ```
+2. Aplique as migrações (SQLite por padrão):
+   ```bash
+   dotnet ef database update --project RpgRooms.Infrastructure --startup-project RpgRooms.Web
+   ```
+   Para usar SQL Server, defina `DatabaseProvider=SqlServer` e configure a connection string `SqlServerConnection`.
+3. Execute a aplicação:
+   ```bash
+   dotnet run --project RpgRooms.Web
+   ```
+
+## Credenciais de desenvolvimento
+
+- Usuário: `admin`
+- Senha: `admin`
+
+## Testes
+
+Os testes de regras de negócio podem ser executados com:
+```bash
+dotnet test
+```

--- a/RpgRooms.Core/Entities/Campaign.cs
+++ b/RpgRooms.Core/Entities/Campaign.cs
@@ -1,0 +1,11 @@
+namespace RpgRooms.Core.Entities;
+
+public class Campaign
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public int GameMasterId { get; set; }
+    public User? GameMaster { get; set; }
+    public bool IsFinished { get; set; }
+    public ICollection<User> Players { get; set; } = new List<User>();
+}

--- a/RpgRooms.Core/Entities/User.cs
+++ b/RpgRooms.Core/Entities/User.cs
@@ -1,0 +1,10 @@
+namespace RpgRooms.Core.Entities;
+
+public class User
+{
+    public int Id { get; set; }
+    public string UserName { get; set; } = string.Empty;
+    public string PasswordHash { get; set; } = string.Empty;
+    public bool IsGameMaster { get; set; }
+    public ICollection<Campaign> Campaigns { get; set; } = new List<Campaign>();
+}

--- a/RpgRooms.Core/Policies/IsGameMasterRequirement.cs
+++ b/RpgRooms.Core/Policies/IsGameMasterRequirement.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace RpgRooms.Core.Policies;
+
+public class IsGameMasterRequirement : IAuthorizationRequirement { }
+
+public class IsGameMasterHandler : AuthorizationHandler<IsGameMasterRequirement>
+{
+    protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, IsGameMasterRequirement requirement)
+    {
+        if (context.User.HasClaim("IsGameMaster", "True"))
+            context.Succeed(requirement);
+
+        return Task.CompletedTask;
+    }
+}

--- a/RpgRooms.Core/RpgRooms.Core.csproj
+++ b/RpgRooms.Core/RpgRooms.Core.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/RpgRooms.Core/Services/CampaignService.cs
+++ b/RpgRooms.Core/Services/CampaignService.cs
@@ -1,0 +1,30 @@
+using RpgRooms.Core.Entities;
+
+namespace RpgRooms.Core.Services;
+
+public class CampaignService
+{
+    public const int MaxPlayers = 50;
+
+    public void AddPlayer(Campaign campaign, User player)
+    {
+        if (campaign.IsFinished)
+            throw new InvalidOperationException("Campaign is finished.");
+
+        if (campaign.Players.Count >= MaxPlayers)
+            throw new InvalidOperationException("Campaign reached maximum players.");
+
+        if (campaign.Players.Any(p => p.Id == player.Id))
+            return;
+
+        campaign.Players.Add(player);
+    }
+
+    public void FinalizeCampaign(Campaign campaign, User user)
+    {
+        if (campaign.GameMasterId != user.Id)
+            throw new UnauthorizedAccessException("Only GM can finalize.");
+
+        campaign.IsFinished = true;
+    }
+}

--- a/RpgRooms.Infrastructure/ApplicationDbContext.cs
+++ b/RpgRooms.Infrastructure/ApplicationDbContext.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using RpgRooms.Core.Entities;
+
+namespace RpgRooms.Infrastructure;
+
+public class ApplicationDbContext : DbContext
+{
+    public DbSet<User> Users => Set<User>();
+    public DbSet<Campaign> Campaigns => Set<Campaign>();
+
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+        : base(options)
+    {
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Campaign>()
+            .HasOne(c => c.GameMaster)
+            .WithMany()
+            .HasForeignKey(c => c.GameMasterId);
+
+        modelBuilder.Entity<Campaign>()
+            .HasMany(c => c.Players)
+            .WithMany(u => u.Campaigns)
+            .UsingEntity(j => j.ToTable("CampaignPlayers"));
+    }
+}

--- a/RpgRooms.Infrastructure/DataSeeder.cs
+++ b/RpgRooms.Infrastructure/DataSeeder.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using RpgRooms.Core.Entities;
+
+namespace RpgRooms.Infrastructure;
+
+public static class DataSeeder
+{
+    public static async Task SeedAsync(ApplicationDbContext context)
+    {
+        await context.Database.MigrateAsync();
+
+        if (!context.Users.Any())
+        {
+            var admin = new User { UserName = "admin", PasswordHash = "admin", IsGameMaster = true };
+            context.Users.Add(admin);
+
+            var campaign = new Campaign { Name = "Sample Campaign", GameMaster = admin };
+            context.Campaigns.Add(campaign);
+
+            await context.SaveChangesAsync();
+        }
+    }
+}

--- a/RpgRooms.Infrastructure/Migrations/20240515000000_Initial.cs
+++ b/RpgRooms.Infrastructure/Migrations/20240515000000_Initial.cs
@@ -1,0 +1,87 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RpgRooms.Infrastructure.Migrations
+{
+    public partial class Initial : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Users",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false).Annotation("Sqlite:Autoincrement", true),
+                    UserName = table.Column<string>(nullable: false),
+                    PasswordHash = table.Column<string>(nullable: false),
+                    IsGameMaster = table.Column<bool>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Users", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Campaigns",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false).Annotation("Sqlite:Autoincrement", true),
+                    Name = table.Column<string>(nullable: false),
+                    GameMasterId = table.Column<int>(nullable: false),
+                    IsFinished = table.Column<bool>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Campaigns", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Campaigns_Users_GameMasterId",
+                        column: x => x.GameMasterId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CampaignPlayers",
+                columns: table => new
+                {
+                    CampaignsId = table.Column<int>(nullable: false),
+                    PlayersId = table.Column<int>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CampaignPlayers", x => new { x.CampaignsId, x.PlayersId });
+                    table.ForeignKey(
+                        name: "FK_CampaignPlayers_Campaigns_CampaignsId",
+                        column: x => x.CampaignsId,
+                        principalTable: "Campaigns",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CampaignPlayers_Users_PlayersId",
+                        column: x => x.PlayersId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Campaigns_GameMasterId",
+                table: "Campaigns",
+                column: "GameMasterId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CampaignPlayers_PlayersId",
+                table: "CampaignPlayers",
+                column: "PlayersId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "CampaignPlayers");
+            migrationBuilder.DropTable(name: "Campaigns");
+            migrationBuilder.DropTable(name: "Users");
+        }
+    }
+}

--- a/RpgRooms.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/RpgRooms.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1,0 +1,73 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using RpgRooms.Infrastructure;
+
+#nullable disable
+
+namespace RpgRooms.Infrastructure.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder.HasAnnotation("ProductVersion", "8.0.0");
+
+            modelBuilder.Entity("RpgRooms.Core.Entities.User", b =>
+            {
+                b.Property<int>("Id").ValueGeneratedOnAdd().HasColumnType("INTEGER");
+                b.Property<bool>("IsGameMaster").HasColumnType("INTEGER");
+                b.Property<string>("PasswordHash").IsRequired().HasColumnType("TEXT");
+                b.Property<string>("UserName").IsRequired().HasColumnType("TEXT");
+                b.HasKey("Id");
+                b.ToTable("Users");
+            });
+
+            modelBuilder.Entity("RpgRooms.Core.Entities.Campaign", b =>
+            {
+                b.Property<int>("Id").ValueGeneratedOnAdd().HasColumnType("INTEGER");
+                b.Property<int>("GameMasterId").HasColumnType("INTEGER");
+                b.Property<bool>("IsFinished").HasColumnType("INTEGER");
+                b.Property<string>("Name").IsRequired().HasColumnType("TEXT");
+                b.HasKey("Id");
+                b.HasIndex("GameMasterId");
+                b.ToTable("Campaigns");
+            });
+
+            modelBuilder.Entity("CampaignPlayers", b =>
+            {
+                b.Property<int>("CampaignsId").HasColumnType("INTEGER");
+                b.Property<int>("PlayersId").HasColumnType("INTEGER");
+                b.HasKey("CampaignsId", "PlayersId");
+                b.HasIndex("PlayersId");
+                b.ToTable("CampaignPlayers");
+            });
+
+            modelBuilder.Entity("RpgRooms.Core.Entities.Campaign", b =>
+            {
+                b.HasOne("RpgRooms.Core.Entities.User", "GameMaster")
+                    .WithMany()
+                    .HasForeignKey("GameMasterId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.Navigation("GameMaster");
+            });
+
+            modelBuilder.Entity("CampaignPlayers", b =>
+            {
+                b.HasOne("RpgRooms.Core.Entities.Campaign", null)
+                    .WithMany("Players")
+                    .HasForeignKey("CampaignsId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                b.HasOne("RpgRooms.Core.Entities.User", null)
+                    .WithMany("Campaigns")
+                    .HasForeignKey("PlayersId")
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+            });
+        }
+    }
+}

--- a/RpgRooms.Infrastructure/RpgRooms.Infrastructure.csproj
+++ b/RpgRooms.Infrastructure/RpgRooms.Infrastructure.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\RpgRooms.Core\\RpgRooms.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/RpgRooms.Tests/CampaignServiceTests.cs
+++ b/RpgRooms.Tests/CampaignServiceTests.cs
@@ -1,0 +1,52 @@
+using RpgRooms.Core.Entities;
+using RpgRooms.Core.Services;
+using Xunit;
+
+namespace RpgRooms.Tests;
+
+public class CampaignServiceTests
+{
+    [Fact]
+    public void AddPlayer_LimitsTo50()
+    {
+        var service = new CampaignService();
+        var gm = new User { Id = 1, UserName = "GM" };
+        var campaign = new Campaign { Id = 1, Name = "Test", GameMasterId = gm.Id };
+
+        for (int i = 0; i < CampaignService.MaxPlayers; i++)
+        {
+            service.AddPlayer(campaign, new User { Id = i + 2 });
+        }
+
+        Assert.Equal(CampaignService.MaxPlayers, campaign.Players.Count);
+        Assert.Throws<InvalidOperationException>(() =>
+            service.AddPlayer(campaign, new User { Id = 100 }));
+    }
+
+    [Fact]
+    public void OnlyGameMasterCanFinalize()
+    {
+        var service = new CampaignService();
+        var gm = new User { Id = 1 };
+        var player = new User { Id = 2 };
+        var campaign = new Campaign { GameMasterId = gm.Id };
+
+        service.FinalizeCampaign(campaign, gm);
+        Assert.True(campaign.IsFinished);
+
+        campaign.IsFinished = false;
+        Assert.Throws<UnauthorizedAccessException>(() =>
+            service.FinalizeCampaign(campaign, player));
+    }
+
+    [Fact]
+    public void CannotAddPlayersAfterFinalization()
+    {
+        var service = new CampaignService();
+        var gm = new User { Id = 1 };
+        var campaign = new Campaign { GameMasterId = gm.Id, IsFinished = true };
+
+        Assert.Throws<InvalidOperationException>(() =>
+            service.AddPlayer(campaign, new User { Id = 2 }));
+    }
+}

--- a/RpgRooms.Tests/RpgRooms.Tests.csproj
+++ b/RpgRooms.Tests/RpgRooms.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.6.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.5">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\RpgRooms.Core\\RpgRooms.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/RpgRooms.Web/App.razor
+++ b/RpgRooms.Web/App.razor
@@ -1,0 +1,8 @@
+<Router AppAssembly="@typeof(Program).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" />
+    </Found>
+    <NotFound>
+        <p>Sorry, there's nothing at this address.</p>
+    </NotFound>
+</Router>

--- a/RpgRooms.Web/Hubs/CampaignHub.cs
+++ b/RpgRooms.Web/Hubs/CampaignHub.cs
@@ -1,0 +1,16 @@
+using Microsoft.AspNetCore.SignalR;
+
+namespace RpgRooms.Web.Hubs;
+
+public class CampaignHub : Hub
+{
+    public async Task SendMessage(int campaignId, string user, string message)
+    {
+        await Clients.Group($"campaign-{campaignId}").SendAsync("ReceiveMessage", user, message);
+    }
+
+    public async Task JoinCampaign(int campaignId)
+    {
+        await Groups.AddToGroupAsync(Context.ConnectionId, $"campaign-{campaignId}");
+    }
+}

--- a/RpgRooms.Web/Pages/Campaign.razor
+++ b/RpgRooms.Web/Pages/Campaign.razor
@@ -1,0 +1,47 @@
+@page "/campaign/{id:int}"
+@inject ApplicationDbContext Db
+@inject RpgRooms.Core.Services.CampaignService Service
+
+<h3>@campaign?.Name</h3>
+
+@if (campaign is not null)
+{
+    <p>Players (@campaign.Players.Count):</p>
+    <ul>
+        @foreach (var p in campaign.Players)
+        {
+            <li>@p.UserName</li>
+        }
+    </ul>
+    @if (!campaign.IsFinished)
+    {
+        <button @onclick="Finalize">Finalize Campaign</button>
+    }
+    else
+    {
+        <p>Campaign finished.</p>
+    }
+}
+
+@code {
+    [Parameter] public int id { get; set; }
+    private Campaign? campaign;
+    private User? currentUser;
+
+    protected override void OnInitialized()
+    {
+        campaign = Db.Campaigns.Include(c => c.Players).FirstOrDefault(c => c.Id == id);
+        currentUser = Db.Users.FirstOrDefault(u => u.UserName == "admin");
+    }
+
+    private void Finalize()
+    {
+        if (campaign is null || currentUser is null) return;
+        try
+        {
+            Service.FinalizeCampaign(campaign, currentUser);
+            Db.SaveChanges();
+        }
+        catch { }
+    }
+}

--- a/RpgRooms.Web/Pages/Index.razor
+++ b/RpgRooms.Web/Pages/Index.razor
@@ -1,0 +1,27 @@
+@page "/"
+@inject ApplicationDbContext Db
+
+<h3>Campaigns</h3>
+
+@if (campaigns is null)
+{
+    <p>Loading...</p>
+}
+else
+{
+    <ul>
+        @foreach (var c in campaigns)
+        {
+            <li><a href="/campaign/@c.Id">@c.Name (@c.Players.Count)</a></li>
+        }
+    </ul>
+}
+
+@code {
+    private List<Campaign>? campaigns;
+
+    protected override void OnInitialized()
+    {
+        campaigns = Db.Campaigns.Include(c => c.Players).ToList();
+    }
+}

--- a/RpgRooms.Web/Pages/_Host.cshtml
+++ b/RpgRooms.Web/Pages/_Host.cshtml
@@ -1,0 +1,16 @@
+@page "/"
+@namespace RpgRooms.Web.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>RpgRooms</title>
+</head>
+<body>
+    <app>
+        @(await Html.RenderComponentAsync<App>(RenderMode.Server))
+    </app>
+    <script src="_framework/blazor.server.js"></script>
+</body>
+</html>

--- a/RpgRooms.Web/Program.cs
+++ b/RpgRooms.Web/Program.cs
@@ -1,0 +1,52 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.EntityFrameworkCore;
+using RpgRooms.Infrastructure;
+using RpgRooms.Core.Services;
+using RpgRooms.Web.Hubs;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var connection = builder.Configuration.GetConnectionString("DefaultConnection") ?? "Data Source=rpgrooms.db";
+
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+{
+    options.UseSqlite(connection);
+    var provider = builder.Configuration.GetValue<string>("DatabaseProvider");
+    if (provider == "SqlServer")
+        options.UseSqlServer(builder.Configuration.GetConnectionString("SqlServerConnection"));
+});
+
+builder.Services.AddSignalR();
+builder.Services.AddScoped<CampaignService>();
+builder.Services.AddRazorPages();
+builder.Services.AddServerSideBlazor();
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("IsGameMaster", policy => policy.RequireClaim("IsGameMaster", "True"));
+});
+
+var app = builder.Build();
+
+using (var scope = app.Services.CreateScope())
+{
+    var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+    await DataSeeder.SeedAsync(db);
+}
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error");
+    app.UseHsts();
+}
+
+app.UseStaticFiles();
+app.UseRouting();
+
+app.MapBlazorHub();
+app.MapHub<CampaignHub>("/campaignHub");
+app.MapFallbackToPage("/_Host");
+
+app.Run();

--- a/RpgRooms.Web/RpgRooms.Web.csproj
+++ b/RpgRooms.Web/RpgRooms.Web.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\RpgRooms.Core\\RpgRooms.Core.csproj" />
+    <ProjectReference Include="..\\RpgRooms.Infrastructure\\RpgRooms.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/RpgRooms.Web/_Imports.razor
+++ b/RpgRooms.Web/_Imports.razor
@@ -1,0 +1,3 @@
+@using RpgRooms.Core.Entities
+@using RpgRooms.Infrastructure
+@using Microsoft.EntityFrameworkCore

--- a/RpgRooms.sln
+++ b/RpgRooms.sln
@@ -1,0 +1,36 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RpgRooms.Core", "RpgRooms.Core/RpgRooms.Core.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RpgRooms.Infrastructure", "RpgRooms.Infrastructure/RpgRooms.Infrastructure.csproj", "{22222222-2222-2222-2222-222222222222}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RpgRooms.Web", "RpgRooms.Web/RpgRooms.Web.csproj", "{33333333-3333-3333-3333-333333333333}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RpgRooms.Tests", "RpgRooms.Tests/RpgRooms.Tests.csproj", "{44444444-4444-4444-4444-444444444444}"
+EndProject
+Global
+    GlobalSection(SolutionConfigurationPlatforms) = preSolution
+        Debug|Any CPU = Debug|Any CPU
+        Release|Any CPU = Release|Any CPU
+    EndGlobalSection
+    GlobalSection(ProjectConfigurationPlatforms) = postSolution
+        {11111111-1111-1111-1111-111111111111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {11111111-1111-1111-1111-111111111111}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {11111111-1111-1111-1111-111111111111}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {11111111-1111-1111-1111-111111111111}.Release|Any CPU.Build.0 = Release|Any CPU
+        {22222222-2222-2222-2222-222222222222}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {22222222-2222-2222-2222-222222222222}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {22222222-2222-2222-2222-222222222222}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {22222222-2222-2222-2222-222222222222}.Release|Any CPU.Build.0 = Release|Any CPU
+        {33333333-3333-3333-3333-333333333333}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {33333333-3333-3333-3333-333333333333}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {33333333-3333-3333-3333-333333333333}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {33333333-3333-3333-3333-333333333333}.Release|Any CPU.Build.0 = Release|Any CPU
+        {44444444-4444-4444-4444-444444444444}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+        {44444444-4444-4444-4444-444444444444}.Debug|Any CPU.Build.0 = Debug|Any CPU
+        {44444444-4444-4444-4444-444444444444}.Release|Any CPU.ActiveCfg = Release|Any CPU
+        {44444444-4444-4444-4444-444444444444}.Release|Any CPU.Build.0 = Release|Any CPU
+    EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- scaffold multi-project .NET solution for RpgRooms
- add core domain entities and services with business rules
- configure EF Core with SQLite and optional SQL Server
- seed development data and initial migrations
- stub Blazor web app with SignalR hub and pages
- include xUnit tests for critical rules

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b085b66ef083329ff5faf5d73c5d34