### PR TITLE
Add System.Linq namespace to services

### DIFF
--- a/RpgRooms.Core/Services/CampaignService.cs
+++ b/RpgRooms.Core/Services/CampaignService.cs
@@ -1,4 +1,5 @@
 using RpgRooms.Core.Entities;
+using System.Linq;
 
 namespace RpgRooms.Core.Services;
 

--- a/RpgRooms.Infrastructure/DataSeeder.cs
+++ b/RpgRooms.Infrastructure/DataSeeder.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using RpgRooms.Core.Entities;
+using System.Linq;
 
 namespace RpgRooms.Infrastructure;
 


### PR DESCRIPTION
## Summary
- include System.Linq in CampaignService for LINQ methods
- include System.Linq in DataSeeder for database seeding

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet ef database update --project RpgRooms.Infrastructure --startup-project RpgRooms.Web` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b08c840594833285091e84c175de63