### PR TITLE
Fix build by renaming campaign page and adding Blazor usings

### DIFF
--- a/RpgRooms.Web/Pages/CampaignDetails.razor
+++ b/RpgRooms.Web/Pages/CampaignDetails.razor
@@ -15,7 +15,7 @@
     </ul>
     @if (!campaign.IsFinished)
     {
-        <button @onclick="Finalize">Finalize Campaign</button>
+        <button @onclick="FinalizeCampaign">Finalize Campaign</button>
     }
     else
     {
@@ -34,7 +34,7 @@
         currentUser = Db.Users.FirstOrDefault(u => u.UserName == "admin");
     }
 
-    private void Finalize()
+    private void FinalizeCampaign()
     {
         if (campaign is null || currentUser is null) return;
         try

--- a/RpgRooms.Web/_Imports.razor
+++ b/RpgRooms.Web/_Imports.razor
@@ -1,3 +1,5 @@
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Routing
 @using RpgRooms.Core.Entities
 @using RpgRooms.Infrastructure
 @using Microsoft.EntityFrameworkCore


### PR DESCRIPTION
## Summary
- add missing Blazor usings for Router support
- rename Campaign page to avoid collision with entity
- rename finalization handler to avoid destructor warning

## Testing
- `dotnet build` *(fails: command not found: dotnet)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b0965a99c48332b02f2fccce16bacf