### PR TITLE
docs: add required dotnet-ef tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 Projeto de exemplo de salas para campanhas de RPG usando Blazor, EF Core e SignalR.
 
+## Ferramentas necessárias
+
+Para aplicar as migrações do Entity Framework Core é necessário ter a ferramenta de linha de comando `dotnet-ef` instalada.
+
+```bash
+dotnet tool install --global dotnet-ef
+```
+
+Se a ferramenta já estiver instalada, atualize-a:
+
+```bash
+dotnet tool update --global dotnet-ef
+```
+
+O comando `dotnet ef database update` utilizado na seção de execução depende dessa ferramenta.
+
 ## Execução
 
 Certifique-se de ter o .NET SDK 8.0 instalado. O projeto `RpgRooms.Core`


### PR DESCRIPTION
## Summary
- document required dotnet-ef CLI and installation steps
- note that database update command relies on the dotnet-ef tool

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*
- `curl -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh` *(fails: CONNECT tunnel 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b09e4f0b7c8332b8e7f05e7bdb8560