### PR TITLE
Align EF Core packages to net8 versions

### DIFF
--- a/RpgRooms.Infrastructure/RpgRooms.Infrastructure.csproj
+++ b/RpgRooms.Infrastructure/RpgRooms.Infrastructure.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/RpgRooms.Web/RpgRooms.Web.csproj
+++ b/RpgRooms.Web/RpgRooms.Web.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary
- Align EF Core packages in Infrastructure and Web projects to version 8.0.0 to avoid downgrade errors

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a1e36b9c8332b20945836e38c0a1