### PR TITLE
feat: expand campaign domain and database

### DIFF
--- a/RpgRooms.Core/Entities/ApplicationUser.cs
+++ b/RpgRooms.Core/Entities/ApplicationUser.cs
@@ -5,6 +5,10 @@ namespace RpgRooms.Core.Entities;
 public class ApplicationUser : IdentityUser
 {
     public bool IsGameMaster { get; set; }
-    public ICollection<Campaign> Campaigns { get; set; } = new List<Campaign>();
+    public ICollection<Campaign> OwnedCampaigns { get; set; } = new List<Campaign>();
+    public ICollection<CampaignMember> CampaignMemberships { get; set; } = new List<CampaignMember>();
+    public ICollection<JoinRequest> JoinRequests { get; set; } = new List<JoinRequest>();
+    public ICollection<ChatMessage> ChatMessages { get; set; } = new List<ChatMessage>();
+    public ICollection<AuditEntry> AuditEntries { get; set; } = new List<AuditEntry>();
 }
 

--- a/RpgRooms.Core/Entities/AuditEntry.cs
+++ b/RpgRooms.Core/Entities/AuditEntry.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace RpgRooms.Core.Entities;
+
+public class AuditEntry
+{
+    public int Id { get; set; }
+    public int CampaignId { get; set; }
+    public Campaign? Campaign { get; set; }
+    public string UserId { get; set; } = string.Empty;
+    public ApplicationUser? User { get; set; }
+    public string Action { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/RpgRooms.Core/Entities/Campaign.cs
+++ b/RpgRooms.Core/Entities/Campaign.cs
@@ -1,11 +1,24 @@
+using System;
+using System.Collections.Generic;
+
 namespace RpgRooms.Core.Entities;
 
 public class Campaign
 {
     public int Id { get; set; }
     public string Name { get; set; } = string.Empty;
-    public string GameMasterId { get; set; } = string.Empty;
-    public ApplicationUser? GameMaster { get; set; }
-    public bool IsFinished { get; set; }
-    public ICollection<ApplicationUser> Players { get; set; } = new List<ApplicationUser>();
+    public string Description { get; set; } = string.Empty;
+    public string OwnerUserId { get; set; } = string.Empty;
+    public ApplicationUser? OwnerUser { get; set; }
+    public CampaignStatus Status { get; set; } = CampaignStatus.Active;
+    public bool IsRecruiting { get; set; }
+    public int MaxPlayers { get; set; } = 5;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime? UpdatedAt { get; set; }
+    public DateTime? FinalizedAt { get; set; }
+
+    public ICollection<CampaignMember> Members { get; set; } = new List<CampaignMember>();
+    public ICollection<JoinRequest> JoinRequests { get; set; } = new List<JoinRequest>();
+    public ICollection<ChatMessage> ChatMessages { get; set; } = new List<ChatMessage>();
+    public ICollection<AuditEntry> AuditEntries { get; set; } = new List<AuditEntry>();
 }

--- a/RpgRooms.Core/Entities/CampaignMember.cs
+++ b/RpgRooms.Core/Entities/CampaignMember.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace RpgRooms.Core.Entities;
+
+public class CampaignMember
+{
+    public int Id { get; set; }
+    public int CampaignId { get; set; }
+    public Campaign? Campaign { get; set; }
+    public string UserId { get; set; } = string.Empty;
+    public ApplicationUser? User { get; set; }
+    public DateTime JoinedAt { get; set; } = DateTime.UtcNow;
+}

--- a/RpgRooms.Core/Entities/CampaignStatus.cs
+++ b/RpgRooms.Core/Entities/CampaignStatus.cs
@@ -1,0 +1,7 @@
+namespace RpgRooms.Core.Entities;
+
+public enum CampaignStatus
+{
+    Active,
+    Finalized
+}

--- a/RpgRooms.Core/Entities/ChatMessage.cs
+++ b/RpgRooms.Core/Entities/ChatMessage.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace RpgRooms.Core.Entities;
+
+public class ChatMessage
+{
+    public int Id { get; set; }
+    public int CampaignId { get; set; }
+    public Campaign? Campaign { get; set; }
+    public string UserId { get; set; } = string.Empty;
+    public ApplicationUser? User { get; set; }
+    public string Message { get; set; } = string.Empty;
+    public DateTime SentAt { get; set; } = DateTime.UtcNow;
+}

--- a/RpgRooms.Core/Entities/JoinRequest.cs
+++ b/RpgRooms.Core/Entities/JoinRequest.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace RpgRooms.Core.Entities;
+
+public class JoinRequest
+{
+    public int Id { get; set; }
+    public int CampaignId { get; set; }
+    public Campaign? Campaign { get; set; }
+    public string UserId { get; set; } = string.Empty;
+    public ApplicationUser? User { get; set; }
+    public string Message { get; set; } = string.Empty;
+    public JoinRequestStatus Status { get; set; } = JoinRequestStatus.Pending;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime? RespondedAt { get; set; }
+}

--- a/RpgRooms.Core/Entities/JoinRequestStatus.cs
+++ b/RpgRooms.Core/Entities/JoinRequestStatus.cs
@@ -1,0 +1,8 @@
+namespace RpgRooms.Core.Entities;
+
+public enum JoinRequestStatus
+{
+    Pending,
+    Approved,
+    Rejected
+}

--- a/RpgRooms.Core/Services/CampaignService.cs
+++ b/RpgRooms.Core/Services/CampaignService.cs
@@ -1,31 +1,37 @@
 using RpgRooms.Core.Entities;
+using System;
 using System.Linq;
 
 namespace RpgRooms.Core.Services;
 
 public class CampaignService
 {
-    public const int MaxPlayers = 50;
-
     public void AddPlayer(Campaign campaign, ApplicationUser player)
     {
-        if (campaign.IsFinished)
+        if (campaign.Status == CampaignStatus.Finalized)
             throw new InvalidOperationException("Campaign is finished.");
 
-        if (campaign.Players.Count >= MaxPlayers)
+        if (campaign.Members.Count >= campaign.MaxPlayers)
             throw new InvalidOperationException("Campaign reached maximum players.");
 
-        if (campaign.Players.Any(p => p.Id == player.Id))
+        if (campaign.Members.Any(m => m.UserId == player.Id))
             return;
 
-        campaign.Players.Add(player);
+        campaign.Members.Add(new CampaignMember
+        {
+            CampaignId = campaign.Id,
+            UserId = player.Id,
+            User = player,
+            JoinedAt = DateTime.UtcNow
+        });
     }
 
     public void FinalizeCampaign(Campaign campaign, ApplicationUser user)
     {
-        if (campaign.GameMasterId != user.Id)
-            throw new UnauthorizedAccessException("Only GM can finalize.");
+        if (campaign.OwnerUserId != user.Id)
+            throw new UnauthorizedAccessException("Only owner can finalize.");
 
-        campaign.IsFinished = true;
+        campaign.Status = CampaignStatus.Finalized;
+        campaign.FinalizedAt = DateTime.UtcNow;
     }
 }

--- a/RpgRooms.Infrastructure/ApplicationDbContext.cs
+++ b/RpgRooms.Infrastructure/ApplicationDbContext.cs
@@ -7,6 +7,10 @@ namespace RpgRooms.Infrastructure;
 public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
 {
     public DbSet<Campaign> Campaigns => Set<Campaign>();
+    public DbSet<CampaignMember> CampaignMembers => Set<CampaignMember>();
+    public DbSet<JoinRequest> JoinRequests => Set<JoinRequest>();
+    public DbSet<ChatMessage> ChatMessages => Set<ChatMessage>();
+    public DbSet<AuditEntry> AuditEntries => Set<AuditEntry>();
 
     public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
         : base(options)
@@ -18,13 +22,51 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
         base.OnModelCreating(modelBuilder);
 
         modelBuilder.Entity<Campaign>()
-            .HasOne(c => c.GameMaster)
-            .WithMany()
-            .HasForeignKey(c => c.GameMasterId);
+            .HasOne(c => c.OwnerUser)
+            .WithMany(u => u.OwnedCampaigns)
+            .HasForeignKey(c => c.OwnerUserId);
 
         modelBuilder.Entity<Campaign>()
-            .HasMany(c => c.Players)
-            .WithMany(u => u.Campaigns)
-            .UsingEntity(j => j.ToTable("CampaignPlayers"));
+            .HasCheckConstraint("CK_Campaign_MaxPlayers", "MaxPlayers <= 50");
+
+        modelBuilder.Entity<CampaignMember>()
+            .HasOne(cm => cm.Campaign)
+            .WithMany(c => c.Members)
+            .HasForeignKey(cm => cm.CampaignId);
+
+        modelBuilder.Entity<CampaignMember>()
+            .HasOne(cm => cm.User)
+            .WithMany(u => u.CampaignMemberships)
+            .HasForeignKey(cm => cm.UserId);
+
+        modelBuilder.Entity<JoinRequest>()
+            .HasOne(j => j.Campaign)
+            .WithMany(c => c.JoinRequests)
+            .HasForeignKey(j => j.CampaignId);
+
+        modelBuilder.Entity<JoinRequest>()
+            .HasOne(j => j.User)
+            .WithMany(u => u.JoinRequests)
+            .HasForeignKey(j => j.UserId);
+
+        modelBuilder.Entity<ChatMessage>()
+            .HasOne(m => m.Campaign)
+            .WithMany(c => c.ChatMessages)
+            .HasForeignKey(m => m.CampaignId);
+
+        modelBuilder.Entity<ChatMessage>()
+            .HasOne(m => m.User)
+            .WithMany(u => u.ChatMessages)
+            .HasForeignKey(m => m.UserId);
+
+        modelBuilder.Entity<AuditEntry>()
+            .HasOne(a => a.Campaign)
+            .WithMany(c => c.AuditEntries)
+            .HasForeignKey(a => a.CampaignId);
+
+        modelBuilder.Entity<AuditEntry>()
+            .HasOne(a => a.User)
+            .WithMany(u => u.AuditEntries)
+            .HasForeignKey(a => a.UserId);
     }
 }

--- a/RpgRooms.Infrastructure/DataSeeder.cs
+++ b/RpgRooms.Infrastructure/DataSeeder.cs
@@ -20,8 +20,24 @@ public static class DataSeeder
             var admin = new ApplicationUser { UserName = "admin", IsGameMaster = true };
             await userManager.CreateAsync(admin, "admin");
 
-            var campaign = new Campaign { Name = "Sample Campaign", GameMasterId = admin.Id, GameMaster = admin };
+            var campaign = new Campaign
+            {
+                Name = "Sample Campaign",
+                Description = "Sample campaign",
+                OwnerUserId = admin.Id,
+                OwnerUser = admin,
+                Status = CampaignStatus.Active,
+                IsRecruiting = true,
+                MaxPlayers = 5,
+                CreatedAt = DateTime.UtcNow
+            };
             context.Campaigns.Add(campaign);
+            context.CampaignMembers.Add(new CampaignMember
+            {
+                Campaign = campaign,
+                User = admin,
+                UserId = admin.Id
+            });
 
             await context.SaveChangesAsync();
         }

--- a/RpgRooms.Infrastructure/Migrations/20240630000000_AddCampaignEntities.cs
+++ b/RpgRooms.Infrastructure/Migrations/20240630000000_AddCampaignEntities.cs
@@ -1,0 +1,212 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RpgRooms.Infrastructure.Migrations
+{
+    public partial class AddCampaignEntities : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Campaigns",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false).Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(nullable: false),
+                    Description = table.Column<string>(nullable: false),
+                    OwnerUserId = table.Column<string>(nullable: false),
+                    Status = table.Column<int>(nullable: false),
+                    IsRecruiting = table.Column<bool>(nullable: false),
+                    MaxPlayers = table.Column<int>(nullable: false),
+                    CreatedAt = table.Column<DateTime>(nullable: false),
+                    UpdatedAt = table.Column<DateTime>(nullable: true),
+                    FinalizedAt = table.Column<DateTime>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Campaigns", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Campaigns_AspNetUsers_OwnerUserId",
+                        column: x => x.OwnerUserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.CheckConstraint("CK_Campaign_MaxPlayers", "MaxPlayers <= 50");
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AuditEntries",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false).Annotation("SqlServer:Identity", "1, 1"),
+                    CampaignId = table.Column<int>(nullable: false),
+                    UserId = table.Column<string>(nullable: false),
+                    Action = table.Column<string>(nullable: false),
+                    CreatedAt = table.Column<DateTime>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AuditEntries", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AuditEntries_Campaigns_CampaignId",
+                        column: x => x.CampaignId,
+                        principalTable: "Campaigns",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_AuditEntries_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "CampaignMembers",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false).Annotation("SqlServer:Identity", "1, 1"),
+                    CampaignId = table.Column<int>(nullable: false),
+                    UserId = table.Column<string>(nullable: false),
+                    JoinedAt = table.Column<DateTime>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CampaignMembers", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CampaignMembers_Campaigns_CampaignId",
+                        column: x => x.CampaignId,
+                        principalTable: "Campaigns",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_CampaignMembers_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ChatMessages",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false).Annotation("SqlServer:Identity", "1, 1"),
+                    CampaignId = table.Column<int>(nullable: false),
+                    UserId = table.Column<string>(nullable: false),
+                    Message = table.Column<string>(nullable: false),
+                    SentAt = table.Column<DateTime>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChatMessages", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ChatMessages_Campaigns_CampaignId",
+                        column: x => x.CampaignId,
+                        principalTable: "Campaigns",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ChatMessages_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "JoinRequests",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false).Annotation("SqlServer:Identity", "1, 1"),
+                    CampaignId = table.Column<int>(nullable: false),
+                    UserId = table.Column<string>(nullable: false),
+                    Message = table.Column<string>(nullable: false),
+                    Status = table.Column<int>(nullable: false),
+                    CreatedAt = table.Column<DateTime>(nullable: false),
+                    RespondedAt = table.Column<DateTime>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_JoinRequests", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_JoinRequests_Campaigns_CampaignId",
+                        column: x => x.CampaignId,
+                        principalTable: "Campaigns",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_JoinRequests_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Campaigns_OwnerUserId",
+                table: "Campaigns",
+                column: "OwnerUserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AuditEntries_CampaignId",
+                table: "AuditEntries",
+                column: "CampaignId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AuditEntries_UserId",
+                table: "AuditEntries",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CampaignMembers_CampaignId",
+                table: "CampaignMembers",
+                column: "CampaignId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CampaignMembers_UserId",
+                table: "CampaignMembers",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChatMessages_CampaignId",
+                table: "ChatMessages",
+                column: "CampaignId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ChatMessages_UserId",
+                table: "ChatMessages",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_JoinRequests_CampaignId",
+                table: "JoinRequests",
+                column: "CampaignId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_JoinRequests_UserId",
+                table: "JoinRequests",
+                column: "UserId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AuditEntries");
+
+            migrationBuilder.DropTable(
+                name: "CampaignMembers");
+
+            migrationBuilder.DropTable(
+                name: "ChatMessages");
+
+            migrationBuilder.DropTable(
+                name: "JoinRequests");
+
+            migrationBuilder.DropTable(
+                name: "Campaigns");
+        }
+    }
+}

--- a/RpgRooms.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/RpgRooms.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1,0 +1,90 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using RpgRooms.Core.Entities;
+
+#nullable disable
+
+namespace RpgRooms.Infrastructure.Migrations
+{
+    [DbContext(typeof(ApplicationDbContext))]
+    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder.HasAnnotation("ProductVersion", "8.0.0");
+
+            modelBuilder.Entity<Campaign>(b =>
+            {
+                b.Property<int>("Id").ValueGeneratedOnAdd();
+                b.Property<string>("Name").IsRequired();
+                b.Property<string>("Description").IsRequired();
+                b.Property<string>("OwnerUserId").IsRequired();
+                b.Property<int>("Status");
+                b.Property<bool>("IsRecruiting");
+                b.Property<int>("MaxPlayers");
+                b.Property<DateTime>("CreatedAt");
+                b.Property<DateTime?>("UpdatedAt");
+                b.Property<DateTime?>("FinalizedAt");
+                b.HasKey("Id");
+                b.HasIndex("OwnerUserId");
+                b.ToTable("Campaigns");
+            });
+
+            modelBuilder.Entity<CampaignMember>(b =>
+            {
+                b.Property<int>("Id").ValueGeneratedOnAdd();
+                b.Property<int>("CampaignId");
+                b.Property<string>("UserId").IsRequired();
+                b.Property<DateTime>("JoinedAt");
+                b.HasKey("Id");
+                b.HasIndex("CampaignId");
+                b.HasIndex("UserId");
+                b.ToTable("CampaignMembers");
+            });
+
+            modelBuilder.Entity<JoinRequest>(b =>
+            {
+                b.Property<int>("Id").ValueGeneratedOnAdd();
+                b.Property<int>("CampaignId");
+                b.Property<string>("UserId").IsRequired();
+                b.Property<string>("Message").IsRequired();
+                b.Property<int>("Status");
+                b.Property<DateTime>("CreatedAt");
+                b.Property<DateTime?>("RespondedAt");
+                b.HasKey("Id");
+                b.HasIndex("CampaignId");
+                b.HasIndex("UserId");
+                b.ToTable("JoinRequests");
+            });
+
+            modelBuilder.Entity<ChatMessage>(b =>
+            {
+                b.Property<int>("Id").ValueGeneratedOnAdd();
+                b.Property<int>("CampaignId");
+                b.Property<string>("UserId").IsRequired();
+                b.Property<string>("Message").IsRequired();
+                b.Property<DateTime>("SentAt");
+                b.HasKey("Id");
+                b.HasIndex("CampaignId");
+                b.HasIndex("UserId");
+                b.ToTable("ChatMessages");
+            });
+
+            modelBuilder.Entity<AuditEntry>(b =>
+            {
+                b.Property<int>("Id").ValueGeneratedOnAdd();
+                b.Property<int>("CampaignId");
+                b.Property<string>("UserId").IsRequired();
+                b.Property<string>("Action").IsRequired();
+                b.Property<DateTime>("CreatedAt");
+                b.HasKey("Id");
+                b.HasIndex("CampaignId");
+                b.HasIndex("UserId");
+                b.ToTable("AuditEntries");
+            });
+        }
+    }
+}

--- a/RpgRooms.Tests/CampaignServiceTests.cs
+++ b/RpgRooms.Tests/CampaignServiceTests.cs
@@ -10,31 +10,31 @@ public class CampaignServiceTests
     public void AddPlayer_LimitsTo50()
     {
         var service = new CampaignService();
-        var gm = new ApplicationUser { Id = "1", UserName = "GM" };
-        var campaign = new Campaign { Id = 1, Name = "Test", GameMasterId = gm.Id };
+        var owner = new ApplicationUser { Id = "1", UserName = "Owner" };
+        var campaign = new Campaign { Id = 1, Name = "Test", OwnerUserId = owner.Id, MaxPlayers = 50 };
 
-        for (int i = 0; i < CampaignService.MaxPlayers; i++)
+        for (int i = 0; i < 50; i++)
         {
             service.AddPlayer(campaign, new ApplicationUser { Id = (i + 2).ToString() });
         }
 
-        Assert.Equal(CampaignService.MaxPlayers, campaign.Players.Count);
+        Assert.Equal(50, campaign.Members.Count);
         Assert.Throws<InvalidOperationException>(() =>
             service.AddPlayer(campaign, new ApplicationUser { Id = "100" }));
     }
 
     [Fact]
-    public void OnlyGameMasterCanFinalize()
+    public void OnlyOwnerCanFinalize()
     {
         var service = new CampaignService();
-        var gm = new ApplicationUser { Id = "1" };
+        var owner = new ApplicationUser { Id = "1" };
         var player = new ApplicationUser { Id = "2" };
-        var campaign = new Campaign { GameMasterId = gm.Id };
+        var campaign = new Campaign { OwnerUserId = owner.Id };
 
-        service.FinalizeCampaign(campaign, gm);
-        Assert.True(campaign.IsFinished);
+        service.FinalizeCampaign(campaign, owner);
+        Assert.Equal(CampaignStatus.Finalized, campaign.Status);
 
-        campaign.IsFinished = false;
+        campaign.Status = CampaignStatus.Active;
         Assert.Throws<UnauthorizedAccessException>(() =>
             service.FinalizeCampaign(campaign, player));
     }
@@ -43,8 +43,8 @@ public class CampaignServiceTests
     public void CannotAddPlayersAfterFinalization()
     {
         var service = new CampaignService();
-        var gm = new ApplicationUser { Id = "1" };
-        var campaign = new Campaign { GameMasterId = gm.Id, IsFinished = true };
+        var owner = new ApplicationUser { Id = "1" };
+        var campaign = new Campaign { OwnerUserId = owner.Id, Status = CampaignStatus.Finalized };
 
         Assert.Throws<InvalidOperationException>(() =>
             service.AddPlayer(campaign, new ApplicationUser { Id = "2" }));

--- a/RpgRooms.Web/Pages/CampaignDetails.razor
+++ b/RpgRooms.Web/Pages/CampaignDetails.razor
@@ -6,14 +6,14 @@
 
 @if (campaign is not null)
 {
-    <p>Players (@campaign.Players.Count):</p>
+    <p>Players (@campaign.Members.Count):</p>
     <ul>
-        @foreach (var p in campaign.Players)
+        @foreach (var m in campaign.Members)
         {
-            <li>@p.UserName</li>
+            <li>@m.User?.UserName</li>
         }
     </ul>
-    @if (!campaign.IsFinished)
+    @if (campaign.Status != CampaignStatus.Finalized)
     {
         <button @onclick="FinalizeCampaign">Finalize Campaign</button>
     }
@@ -30,7 +30,7 @@
 
     protected override void OnInitialized()
     {
-        campaign = Db.Campaigns.Include(c => c.Players).FirstOrDefault(c => c.Id == id);
+        campaign = Db.Campaigns.Include(c => c.Members).ThenInclude(m => m.User).FirstOrDefault(c => c.Id == id);
         currentUser = Db.Users.FirstOrDefault(u => u.UserName == "admin");
     }
 

--- a/RpgRooms.Web/Pages/Index.razor
+++ b/RpgRooms.Web/Pages/Index.razor
@@ -12,7 +12,7 @@ else
     <ul>
         @foreach (var c in campaigns)
         {
-            <li><a href="/campaign/@c.Id">@c.Name (@c.Players.Count)</a></li>
+            <li><a href="/campaign/@c.Id">@c.Name (@c.Members.Count)</a></li>
         }
     </ul>
 }
@@ -22,6 +22,6 @@ else
 
     protected override void OnInitialized()
     {
-        campaigns = Db.Campaigns.Include(c => c.Players).ToList();
+        campaigns = Db.Campaigns.Include(c => c.Members).ToList();
     }
 }


### PR DESCRIPTION
## Summary
- add campaign lifecycle fields and related entities
- configure EF context and migration for campaign membership, join requests, chat and audit
- update pages, seeder and tests for new campaign model

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b0ab20662483329ab110013dec34a1