### PR TITLE
Add campaign join requests and recruitment management

### DIFF
--- a/RpgRooms.Core/Services/CampaignService.cs
+++ b/RpgRooms.Core/Services/CampaignService.cs
@@ -11,6 +11,9 @@ public class CampaignService
         if (campaign.Status == CampaignStatus.Finalized)
             throw new InvalidOperationException("Campaign is finished.");
 
+        if (campaign.MaxPlayers > 50)
+            throw new InvalidOperationException("Max players cannot exceed 50.");
+
         if (campaign.Members.Count >= campaign.MaxPlayers)
             throw new InvalidOperationException("Campaign reached maximum players.");
 
@@ -24,6 +27,9 @@ public class CampaignService
             User = player,
             JoinedAt = DateTime.UtcNow
         });
+
+        if (campaign.Members.Count >= campaign.MaxPlayers || campaign.Members.Count >= 50)
+            campaign.IsRecruiting = false;
     }
 
     public void FinalizeCampaign(Campaign campaign, ApplicationUser user)
@@ -33,5 +39,100 @@ public class CampaignService
 
         campaign.Status = CampaignStatus.Finalized;
         campaign.FinalizedAt = DateTime.UtcNow;
+    }
+
+    public JoinRequest RequestToJoin(Campaign campaign, ApplicationUser user, string message)
+    {
+        if (!campaign.IsRecruiting)
+            throw new InvalidOperationException("Campaign is not recruiting.");
+
+        if (campaign.MaxPlayers > 50)
+            throw new InvalidOperationException("Max players cannot exceed 50.");
+
+        if (campaign.Members.Any(m => m.UserId == user.Id))
+            throw new InvalidOperationException("User already a member.");
+
+        if (campaign.JoinRequests.Any(r => r.UserId == user.Id && r.Status == JoinRequestStatus.Pending))
+            throw new InvalidOperationException("Join request already pending.");
+
+        var request = new JoinRequest
+        {
+            CampaignId = campaign.Id,
+            UserId = user.Id,
+            User = user,
+            Message = message,
+            Status = JoinRequestStatus.Pending,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        campaign.JoinRequests.Add(request);
+        return request;
+    }
+
+    public void ApproveRequest(Campaign campaign, JoinRequest request, ApplicationUser user)
+    {
+        if (campaign.OwnerUserId != user.Id)
+            throw new UnauthorizedAccessException("Only owner can approve.");
+
+        if (request.CampaignId != campaign.Id)
+            throw new InvalidOperationException("Request does not belong to campaign.");
+
+        if (request.Status != JoinRequestStatus.Pending)
+            throw new InvalidOperationException("Request already processed.");
+
+        if (request.User == null)
+            throw new InvalidOperationException("Request has no user.");
+
+        AddPlayer(campaign, request.User);
+
+        request.Status = JoinRequestStatus.Approved;
+        request.RespondedAt = DateTime.UtcNow;
+
+        if (campaign.Members.Count >= campaign.MaxPlayers || campaign.Members.Count >= 50)
+            campaign.IsRecruiting = false;
+    }
+
+    public void RejectRequest(Campaign campaign, JoinRequest request, ApplicationUser user)
+    {
+        if (campaign.OwnerUserId != user.Id)
+            throw new UnauthorizedAccessException("Only owner can reject.");
+
+        if (request.CampaignId != campaign.Id)
+            throw new InvalidOperationException("Request does not belong to campaign.");
+
+        if (request.Status != JoinRequestStatus.Pending)
+            throw new InvalidOperationException("Request already processed.");
+
+        request.Status = JoinRequestStatus.Rejected;
+        request.RespondedAt = DateTime.UtcNow;
+    }
+
+    public void RemoveMember(Campaign campaign, string userId, ApplicationUser user)
+    {
+        if (campaign.OwnerUserId != user.Id)
+            throw new UnauthorizedAccessException("Only owner can remove members.");
+
+        var member = campaign.Members.FirstOrDefault(m => m.UserId == userId);
+        if (member == null)
+            throw new InvalidOperationException("Member not found.");
+
+        campaign.Members.Remove(member);
+    }
+
+    public void ToggleRecruitment(Campaign campaign, ApplicationUser user)
+    {
+        if (campaign.OwnerUserId != user.Id)
+            throw new UnauthorizedAccessException("Only owner can toggle recruitment.");
+
+        if (campaign.MaxPlayers > 50)
+            throw new InvalidOperationException("Max players cannot exceed 50.");
+
+        if (campaign.Members.Count >= campaign.MaxPlayers || campaign.Members.Count >= 50)
+        {
+            campaign.IsRecruiting = false;
+            return;
+        }
+
+        campaign.IsRecruiting = !campaign.IsRecruiting;
     }
 }

--- a/RpgRooms.Tests/CampaignServiceTests.cs
+++ b/RpgRooms.Tests/CampaignServiceTests.cs
@@ -49,4 +49,26 @@ public class CampaignServiceTests
         Assert.Throws<InvalidOperationException>(() =>
             service.AddPlayer(campaign, new ApplicationUser { Id = "2" }));
     }
+
+    [Fact]
+    public void ApprovingRequestDisablesRecruitmentAt50()
+    {
+        var service = new CampaignService();
+        var owner = new ApplicationUser { Id = "1" };
+        var campaign = new Campaign { Id = 1, OwnerUserId = owner.Id, IsRecruiting = true, MaxPlayers = 50 };
+
+        for (int i = 0; i < 49; i++)
+        {
+            service.AddPlayer(campaign, new ApplicationUser { Id = (i + 2).ToString() });
+        }
+
+        var newUser = new ApplicationUser { Id = "100" };
+        var request = service.RequestToJoin(campaign, newUser, "let me in");
+
+        service.ApproveRequest(campaign, request, owner);
+
+        Assert.Equal(50, campaign.Members.Count);
+        Assert.False(campaign.IsRecruiting);
+        Assert.Equal(JoinRequestStatus.Approved, request.Status);
+    }
 }

--- a/RpgRooms.Web/Program.cs
+++ b/RpgRooms.Web/Program.cs
@@ -8,6 +8,8 @@ using RpgRooms.Core.Entities;
 using RpgRooms.Core.Services;
 using RpgRooms.Infrastructure;
 using RpgRooms.Web.Hubs;
+using System.Security.Claims;
+using System.Linq;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -53,8 +55,166 @@ app.UseRouting();
 app.UseAuthentication();
 app.UseAuthorization();
 
+app.MapPost("/api/campaigns/{id}/join-requests", async (int id, JoinRequestDto dto, UserManager<ApplicationUser> userManager, CampaignService service, ApplicationDbContext db, ClaimsPrincipal principal) =>
+{
+    var user = await userManager.GetUserAsync(principal);
+    if (user is null)
+        return Results.Unauthorized();
+
+    var campaign = await db.Campaigns
+        .Include(c => c.Members)
+        .Include(c => c.JoinRequests)
+        .FirstOrDefaultAsync(c => c.Id == id);
+
+    if (campaign is null)
+        return Results.NotFound();
+
+    try
+    {
+        service.RequestToJoin(campaign, user, dto.Message);
+        await db.SaveChangesAsync();
+        return Results.Ok();
+    }
+    catch (UnauthorizedAccessException)
+    {
+        return Results.Forbid();
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
+}).RequireAuthorization();
+
+app.MapPost("/api/campaigns/{id}/join-requests/{requestId}/approve", async (int id, int requestId, UserManager<ApplicationUser> userManager, CampaignService service, ApplicationDbContext db, ClaimsPrincipal principal) =>
+{
+    var user = await userManager.GetUserAsync(principal);
+    if (user is null)
+        return Results.Unauthorized();
+
+    var campaign = await db.Campaigns
+        .Include(c => c.Members)
+        .Include(c => c.JoinRequests)
+        .ThenInclude(r => r.User)
+        .FirstOrDefaultAsync(c => c.Id == id);
+
+    if (campaign is null)
+        return Results.NotFound();
+
+    var request = campaign.JoinRequests.FirstOrDefault(r => r.Id == requestId);
+    if (request is null)
+        return Results.NotFound();
+
+    try
+    {
+        service.ApproveRequest(campaign, request, user);
+        await db.SaveChangesAsync();
+        return Results.Ok();
+    }
+    catch (UnauthorizedAccessException)
+    {
+        return Results.Forbid();
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
+}).RequireAuthorization();
+
+app.MapPost("/api/campaigns/{id}/join-requests/{requestId}/reject", async (int id, int requestId, UserManager<ApplicationUser> userManager, CampaignService service, ApplicationDbContext db, ClaimsPrincipal principal) =>
+{
+    var user = await userManager.GetUserAsync(principal);
+    if (user is null)
+        return Results.Unauthorized();
+
+    var campaign = await db.Campaigns
+        .Include(c => c.JoinRequests)
+        .FirstOrDefaultAsync(c => c.Id == id);
+
+    if (campaign is null)
+        return Results.NotFound();
+
+    var request = campaign.JoinRequests.FirstOrDefault(r => r.Id == requestId);
+    if (request is null)
+        return Results.NotFound();
+
+    try
+    {
+        service.RejectRequest(campaign, request, user);
+        await db.SaveChangesAsync();
+        return Results.Ok();
+    }
+    catch (UnauthorizedAccessException)
+    {
+        return Results.Forbid();
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
+}).RequireAuthorization();
+
+app.MapDelete("/api/campaigns/{id}/members/{userId}", async (int id, string userId, UserManager<ApplicationUser> userManager, CampaignService service, ApplicationDbContext db, ClaimsPrincipal principal) =>
+{
+    var user = await userManager.GetUserAsync(principal);
+    if (user is null)
+        return Results.Unauthorized();
+
+    var campaign = await db.Campaigns
+        .Include(c => c.Members)
+        .FirstOrDefaultAsync(c => c.Id == id);
+
+    if (campaign is null)
+        return Results.NotFound();
+
+    try
+    {
+        service.RemoveMember(campaign, userId, user);
+        await db.SaveChangesAsync();
+        return Results.Ok();
+    }
+    catch (UnauthorizedAccessException)
+    {
+        return Results.Forbid();
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
+}).RequireAuthorization();
+
+app.MapPost("/api/campaigns/{id}/recruitment-toggle", async (int id, UserManager<ApplicationUser> userManager, CampaignService service, ApplicationDbContext db, ClaimsPrincipal principal) =>
+{
+    var user = await userManager.GetUserAsync(principal);
+    if (user is null)
+        return Results.Unauthorized();
+
+    var campaign = await db.Campaigns
+        .Include(c => c.Members)
+        .FirstOrDefaultAsync(c => c.Id == id);
+
+    if (campaign is null)
+        return Results.NotFound();
+
+    try
+    {
+        service.ToggleRecruitment(campaign, user);
+        await db.SaveChangesAsync();
+        return Results.Ok(new { campaign.IsRecruiting });
+    }
+    catch (UnauthorizedAccessException)
+    {
+        return Results.Forbid();
+    }
+    catch (InvalidOperationException ex)
+    {
+        return Results.BadRequest(new { error = ex.Message });
+    }
+}).RequireAuthorization();
+
 app.MapBlazorHub();
 app.MapHub<CampaignHub>("/campaignHub");
 app.MapFallbackToPage("/_Host");
 
 app.Run();
+
+record JoinRequestDto(string Message);


### PR DESCRIPTION
## Summary
- implement join request handling and recruitment toggling in `CampaignService`
- expose minimal API endpoints for join requests, approvals, rejections, member removal, and recruitment toggle
- add tests ensuring recruitment stops at 50 players

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ac73d9f08332acf253451247a350