### PR TITLE
Implement campaign chat group management

### DIFF
--- a/RpgRooms.Core/Entities/ChatMessage.cs
+++ b/RpgRooms.Core/Entities/ChatMessage.cs
@@ -9,6 +9,7 @@ public class ChatMessage
     public Campaign? Campaign { get; set; }
     public string UserId { get; set; } = string.Empty;
     public ApplicationUser? User { get; set; }
+    public string DisplayName { get; set; } = string.Empty;
     public string Message { get; set; } = string.Empty;
     public DateTime SentAt { get; set; } = DateTime.UtcNow;
 }

--- a/RpgRooms.Core/Services/CampaignService.cs
+++ b/RpgRooms.Core/Services/CampaignService.cs
@@ -6,6 +6,9 @@ namespace RpgRooms.Core.Services;
 
 public class CampaignService
 {
+    public bool IsMemberOfCampaign(Campaign campaign, string userId)
+        => campaign.Members.Any(m => m.UserId == userId);
+
     public void AddPlayer(Campaign campaign, ApplicationUser player)
     {
         if (campaign.Status == CampaignStatus.Finalized)

--- a/RpgRooms.Infrastructure/Migrations/20240701000000_AddChatMessageDisplayName.cs
+++ b/RpgRooms.Infrastructure/Migrations/20240701000000_AddChatMessageDisplayName.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RpgRooms.Infrastructure.Migrations
+{
+    public partial class AddChatMessageDisplayName : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "DisplayName",
+                table: "ChatMessages",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DisplayName",
+                table: "ChatMessages");
+        }
+    }
+}

--- a/RpgRooms.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/RpgRooms.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -65,6 +65,7 @@ namespace RpgRooms.Infrastructure.Migrations
                 b.Property<int>("Id").ValueGeneratedOnAdd();
                 b.Property<int>("CampaignId");
                 b.Property<string>("UserId").IsRequired();
+                b.Property<string>("DisplayName").IsRequired();
                 b.Property<string>("Message").IsRequired();
                 b.Property<DateTime>("SentAt");
                 b.HasKey("Id");

--- a/RpgRooms.Web/Hubs/CampaignHub.cs
+++ b/RpgRooms.Web/Hubs/CampaignHub.cs
@@ -1,16 +1,96 @@
+using System;
+using System.Security.Claims;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.EntityFrameworkCore;
+using RpgRooms.Core.Entities;
+using RpgRooms.Core.Services;
+using RpgRooms.Infrastructure;
 
 namespace RpgRooms.Web.Hubs;
 
 public class CampaignHub : Hub
 {
-    public async Task SendMessage(int campaignId, string user, string message)
+    private readonly CampaignService _campaignService;
+    private readonly ApplicationDbContext _db;
+
+    public CampaignHub(CampaignService campaignService, ApplicationDbContext db)
     {
-        await Clients.Group($"campaign-{campaignId}").SendAsync("ReceiveMessage", user, message);
+        _campaignService = campaignService;
+        _db = db;
     }
 
-    public async Task JoinCampaign(int campaignId)
+    public async Task JoinCampaignGroup(int campaignId)
     {
+        var userId = Context.User?.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId is null)
+            return;
+
+        var campaign = await _db.Campaigns
+            .Include(c => c.Members)
+            .FirstOrDefaultAsync(c => c.Id == campaignId);
+
+        if (campaign is null || campaign.Status == CampaignStatus.Finalized)
+            return;
+
+        if (!_campaignService.IsMemberOfCampaign(campaign, userId))
+            return;
+
         await Groups.AddToGroupAsync(Context.ConnectionId, $"campaign-{campaignId}");
+        var name = Context.User?.Identity?.Name ?? userId;
+        await Clients.Group($"campaign-{campaignId}")
+            .SendAsync("SystemNotice", $"{name} joined the campaign.");
+    }
+
+    public async Task LeaveCampaignGroup(int campaignId)
+    {
+        await Groups.RemoveFromGroupAsync(Context.ConnectionId, $"campaign-{campaignId}");
+        var name = Context.User?.Identity?.Name ?? string.Empty;
+        await Clients.Group($"campaign-{campaignId}")
+            .SendAsync("SystemNotice", $"{name} left the campaign.");
+    }
+
+    public async Task SendMessage(int campaignId, string content, bool sentAsCharacter)
+    {
+        var userId = Context.User?.FindFirstValue(ClaimTypes.NameIdentifier);
+        if (userId is null)
+            return;
+
+        var campaign = await _db.Campaigns
+            .Include(c => c.Members)
+            .FirstOrDefaultAsync(c => c.Id == campaignId);
+
+        if (campaign is null || campaign.Status == CampaignStatus.Finalized)
+        {
+            await Clients.Caller.SendAsync("SystemNotice", "Campaign has been finalized.");
+            return;
+        }
+
+        if (!_campaignService.IsMemberOfCampaign(campaign, userId))
+            return;
+
+        var displayName = Context.User?.Identity?.Name ?? userId;
+        if (sentAsCharacter)
+            displayName = $"{displayName} (Character)";
+
+        var message = new ChatMessage
+        {
+            CampaignId = campaignId,
+            UserId = userId,
+            DisplayName = displayName,
+            Message = content,
+            SentAt = DateTime.UtcNow
+        };
+
+        _db.ChatMessages.Add(message);
+        await _db.SaveChangesAsync();
+
+        await Clients.Group($"campaign-{campaignId}")
+            .SendAsync("ReceiveMessage", displayName, content);
+    }
+
+    public async Task NotifyCampaignFinalized(int campaignId)
+    {
+        await Clients.Group($"campaign-{campaignId}")
+            .SendAsync("SystemNotice", "Campaign has been finalized.");
     }
 }


### PR DESCRIPTION
## Summary
- Validate and join campaign chat groups only when member and campaign active
- Persist chat messages with display names and broadcast to group
- Add ChatMessage.DisplayName column and membership helper in CampaignService

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package dotnet-sdk-8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ad9f66e883329586b8c7b4e94781