### PR TITLE
Add range validation for campaign creation

### DIFF
--- a/RpgRooms.Web/Pages/CampaignCreate.razor
+++ b/RpgRooms.Web/Pages/CampaignCreate.razor
@@ -1,6 +1,7 @@
 @page "/campaigns/create"
 @inject HttpClient Http
 @inject NavigationManager Navigation
+@using System.ComponentModel.DataAnnotations
 
 <h3>Criar Campanha</h3>
 
@@ -34,11 +35,12 @@
         Navigation.NavigateTo("/campaigns");
     }
 
-    public class CampaignCreateModel
-    {
-        public string Name { get; set; } = string.Empty;
-        public string Description { get; set; } = string.Empty;
-        public int MaxPlayers { get; set; } = 5;
-        public bool IsRecruiting { get; set; } = true;
-    }
-}
+      public class CampaignCreateModel
+      {
+          public string Name { get; set; } = string.Empty;
+          public string Description { get; set; } = string.Empty;
+          [Range(1, 50)]
+          public int MaxPlayers { get; set; } = 5;
+          public bool IsRecruiting { get; set; } = true;
+      }
+  }

--- a/RpgRooms.Web/Program.cs
+++ b/RpgRooms.Web/Program.cs
@@ -13,6 +13,7 @@ using RpgRooms.Infrastructure.Policies;
 using RpgRooms.Web.Hubs;
 using System.Security.Claims;
 using System.Linq;
+using System.ComponentModel.DataAnnotations;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -105,6 +106,10 @@ app.MapPost("/api/campaigns", async (CampaignCreateDto dto, UserManager<Applicat
     var user = await userManager.GetUserAsync(principal);
     if (user is null)
         return Results.Unauthorized();
+
+    var validationResults = new List<ValidationResult>();
+    if (!Validator.TryValidateObject(dto, new ValidationContext(dto), validationResults, true))
+        return Results.BadRequest(new { Error = validationResults.First().ErrorMessage });
 
     var campaign = new Campaign
     {
@@ -314,5 +319,5 @@ app.MapFallbackToPage("/_Host");
 
 app.Run();
 
-record CampaignCreateDto(string Name, string Description, int MaxPlayers, bool IsRecruiting);
+record CampaignCreateDto(string Name, string Description, [property: Range(1, 50)] int MaxPlayers, bool IsRecruiting);
 record JoinRequestDto(string Message);


### PR DESCRIPTION
## Summary
- enforce MaxPlayers between 1 and 50 for campaign creation DTO and form model
- validate campaign creation requests and return 400 with error details

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b991689c8332a8f75a658708586f