### PR TITLE
Configure database provider via configuration

### DIFF
--- a/RpgRooms.Web/Program.cs
+++ b/RpgRooms.Web/Program.cs
@@ -21,10 +21,11 @@ var connection = builder.Configuration.GetConnectionString("DefaultConnection") 
 
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
 {
-    options.UseSqlite(connection);
     var provider = builder.Configuration.GetValue<string>("DatabaseProvider");
     if (provider == "SqlServer")
         options.UseSqlServer(builder.Configuration.GetConnectionString("SqlServerConnection"));
+    else
+        options.UseSqlite(connection);
 });
 
 builder.Services.AddIdentity<ApplicationUser, IdentityRole>()


### PR DESCRIPTION
## Summary
- configure database provider based on `DatabaseProvider` setting

## Testing
- `dotnet test` *(fails: command not found)*
- `DatabaseProvider=SqlServer dotnet run --project RpgRooms.Web` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0babd3fd08332b47c690fdfc66d50