### PR TITLE
Fix campaign pages missing HttpClient base address

### DIFF
--- a/RpgRooms.Web/Pages/CampaignCreate.razor
+++ b/RpgRooms.Web/Pages/CampaignCreate.razor
@@ -29,6 +29,11 @@
 @code {
     private CampaignCreateModel model = new();
 
+    protected override void OnInitialized()
+    {
+        Http.BaseAddress ??= new Uri(Navigation.BaseUri);
+    }
+
     private async Task HandleValidSubmit()
     {
         await Http.PostAsJsonAsync("/api/campaigns", model);

--- a/RpgRooms.Web/Pages/CampaignDetails.razor
+++ b/RpgRooms.Web/Pages/CampaignDetails.razor
@@ -50,6 +50,7 @@ else
 
     protected override async Task OnInitializedAsync()
     {
+        Http.BaseAddress ??= new Uri(Navigation.BaseUri);
         campaign = await Http.GetFromJsonAsync<CampaignDetailsDto>($"/api/campaigns/{id}");
         if (campaign is not null)
             messages = campaign.Chat.ToList();

--- a/RpgRooms.Web/Pages/Campaigns.razor
+++ b/RpgRooms.Web/Pages/Campaigns.razor
@@ -1,5 +1,6 @@
 @page "/campaigns"
 @inject HttpClient Http
+@inject NavigationManager Navigation
 
 <h3>Campanhas</h3>
 
@@ -26,6 +27,7 @@
 
     protected override async Task OnInitializedAsync()
     {
+        Http.BaseAddress ??= new Uri(Navigation.BaseUri);
         var result = await Http.GetFromJsonAsync<List<CampaignSummary>>("/api/campaigns");
         if (result is not null)
             campaigns = result;


### PR DESCRIPTION
## Summary
- Ensure campaign list and detail pages configure HttpClient base address using the current NavigationManager
- Set base address for campaign creation page before submitting requests

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0bc8a5bd08332948cb7b9991aadb9